### PR TITLE
Add PR Status Integration for Claude Code

### DIFF
--- a/.claude.json
+++ b/.claude.json
@@ -1,0 +1,27 @@
+{
+  "hooks": {
+    "StartSession": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Volumes/BigDog/Documents/git/conways-steinway/scripts/pr_status.sh",
+            "description": "Fetching PR status..."
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "^pr status$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Volumes/BigDog/Documents/git/conways-steinway/scripts/pr_status.sh",
+            "description": "Fetching PR status..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/pr_status.sh
+++ b/scripts/pr_status.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# Script to fetch and display PR status in Claude Code
+# This script requires the GitHub CLI (gh) to be installed and authenticated
+
+# Set this to your repository
+REPO="Jeff-Lowrey/conways-steinway"
+
+# ANSI color codes for formatting
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+PURPLE='\033[0;35m'
+NC='\033[0m' # No Color
+BOLD='\033[1m'
+
+echo -e "${BOLD}${BLUE}🔍 PR Status for ${REPO}${NC}\n"
+
+# Fetch open PRs
+echo -e "${BOLD}Open PRs:${NC}"
+gh pr list --repo "$REPO" --limit 5 --json number,title,author,reviewDecision,mergeable,baseRefName,headRefName,url | \
+  jq -r '.[] | "PR #\(.number): \(.title) by @\(.author.login) [\(.baseRefName) ← \(.headRefName)] \(.url)"' | \
+  while read -r line; do
+    echo -e "  ${GREEN}•${NC} $line"
+  done
+
+echo ""
+
+# Fetch recent PR activity
+echo -e "${BOLD}Recent PR Activity:${NC}"
+gh pr list --repo "$REPO" --state all --limit 5 --json number,title,state,updatedAt,author,url | \
+  jq -r '.[] | "\(.updatedAt) - PR #\(.number): \(.title) [\(.state)] by @\(.author.login) \(.url)"' | \
+  while read -r line; do
+    if [[ "$line" == *"[MERGED]"* ]]; then
+      echo -e "  ${PURPLE}•${NC} $line"
+    elif [[ "$line" == *"[CLOSED]"* ]]; then
+      echo -e "  ${YELLOW}•${NC} $line"
+    else
+      echo -e "  ${BLUE}•${NC} $line"
+    fi
+  done
+
+# Show PR mentions for the user
+echo -e "\n${BOLD}PR Mentions:${NC}"
+gh api graphql -f query='
+  query {
+    search(query: "repo:'$REPO' is:pr is:open mentions:@me", type: ISSUE, first: 5) {
+      edges {
+        node {
+          ... on PullRequest {
+            number
+            title
+            url
+            author {
+              login
+            }
+            updatedAt
+          }
+        }
+      }
+    }
+  }
+' | jq -r '.data.search.edges[] | .node | "PR #\(.number): \(.title) by @\(.author.login) \(.url)"' | \
+  while read -r line; do
+    if [ -n "$line" ]; then
+      echo -e "  ${YELLOW}•${NC} $line"
+    fi
+  done
+
+if [ -z "$(jq -r '.data.search.edges[] | .node | "PR #\(.number)"' <<< "$(gh api graphql -f query='
+  query {
+    search(query: "repo:'$REPO' is:pr is:open mentions:@me", type: ISSUE, first: 5) {
+      edges {
+        node {
+          ... on PullRequest {
+            number
+          }
+        }
+      }
+    }
+  }
+')")" ]; then
+  echo -e "  ${GREEN}•${NC} No PR mentions found"
+fi
+
+echo -e "\n${BOLD}${BLUE}End of PR Status Report${NC}"


### PR DESCRIPTION
This PR adds PR status integration for Claude Code.

## Features

- Adds a script to fetch and display PR status in the console
- Shows open PRs, recent PR activity, and PR mentions
- Configures Claude Code hooks to show PR status at the start of each session
- Adds support for typing 'pr status' to refresh PR status anytime

## Usage

After merging this PR, you can:

1. Start a new Claude Code session to see PR status automatically
2. Type 'pr status' at any time to refresh the PR status display

## Requirements

- GitHub CLI (gh) must be installed and authenticated
- jq must be installed for JSON parsing
- Claude Code hooks must be enabled