### PR TITLE
Add OpenTelemetry integration with high ports

### DIFF
--- a/.claude/scripts/otel/README.md
+++ b/.claude/scripts/otel/README.md
@@ -1,0 +1,18 @@
+# OpenTelemetry Collector distributions
+
+> :warning: **Important note:** Git tags in this repository may change at any time to fix any issues found during a release. They are only meant to trigger Github releases and should not be relied upon.
+
+This repository assembles OpenTelemetry Collector distributions, such as the "core" distribution, or "contrib". It may contain non-official distributions, focused on specific use-cases, such as the load-balancer.
+
+Each distribution contains:
+
+- Binaries for a multitude of platforms and architectures (at least linux_amd64, linux_arm64, windows_amd64 and darwin_arm64)
+- Multi-arch container images (at least amd64 and arm64)
+- Packages to be used with Linux distributions (apk, RPM, deb), Mac OS (brew) for the above-mentioned architectures
+
+More details about each individual distribution can be seen in its own readme files.
+
+Current list of distributions:
+
+- [OpenTelemetry Collector (also known as "otelcol")](./distributions/otelcol)
+- [OpenTelemetry Collector Contrib (also known as "otelcol-contrib")](./distributions/otelcol-contrib)

--- a/.claude/scripts/otel/auto_start_otel.sh
+++ b/.claude/scripts/otel/auto_start_otel.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Function to check if a process is running
+is_running() {
+  pgrep -f "$1" > /dev/null
+  return $?
+}
+
+# Log directory
+LOG_DIR="$HOME/.claude/scripts/otel/logs"
+mkdir -p "$LOG_DIR"
+
+# Log file with timestamp
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+LOG_FILE="$LOG_DIR/otel_startup_$TIMESTAMP.log"
+
+echo "Starting OpenTelemetry integration for Claude Code" > "$LOG_FILE"
+echo "Timestamp: $(date)" >> "$LOG_FILE"
+
+# Export OpenTelemetry environment variables
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+export OTEL_METRICS_EXPORTER=otlp
+export OTEL_LOGS_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:14317
+export OTEL_SERVICE_NAME=claude-code
+export OTEL_RESOURCE_ATTRIBUTES=service.name=claude-code,deployment.environment=local
+
+# Write environment variables to the log
+echo "Environment variables set:" >> "$LOG_FILE"
+env | grep -E 'CLAUDE|OTEL' >> "$LOG_FILE"
+
+# Check if OpenTelemetry collector is already running
+if is_running "otelcol"; then
+  echo "OpenTelemetry collector is already running" >> "$LOG_FILE"
+else
+  echo "Starting OpenTelemetry collector..." >> "$LOG_FILE"
+  cd "$HOME/.claude/scripts/otel"
+  ./otelcol --config=config.yaml >> "$LOG_FILE" 2>&1 &
+  OTEL_PID=$!
+  echo "OpenTelemetry collector started with PID: $OTEL_PID" >> "$LOG_FILE"
+fi
+
+# Check if Docker is running
+if ! docker info > /dev/null 2>&1; then
+  echo "Docker is not running. Prometheus and Grafana will not be started." >> "$LOG_FILE"
+  exit 0
+fi
+
+# Check if Prometheus and Grafana are already running
+if docker ps | grep -q "prometheus"; then
+  echo "Prometheus is already running" >> "$LOG_FILE"
+else
+  echo "Starting Prometheus and Grafana..." >> "$LOG_FILE"
+  cd "$HOME/.claude/scripts/otel"
+  docker-compose up -d >> "$LOG_FILE" 2>&1
+  echo "Prometheus and Grafana started" >> "$LOG_FILE"
+fi
+
+echo "OpenTelemetry integration startup completed" >> "$LOG_FILE"
+
+# Set environment variables for the current session
+# This will be picked up by Claude Code
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+export OTEL_METRICS_EXPORTER=otlp
+export OTEL_LOGS_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:14317

--- a/.claude/scripts/otel/config.yaml
+++ b/.claude/scripts/otel/config.yaml
@@ -1,0 +1,32 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:14317
+      http:
+        endpoint: 0.0.0.0:14318
+
+processors:
+  batch:
+    timeout: 1s
+    send_batch_size: 1024
+
+exporters:
+  logging:
+    verbosity: detailed
+  prometheus:
+    endpoint: 0.0.0.0:19090
+    namespace: claudecode
+    const_labels:
+      service: "claude-code"
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging, prometheus]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging]

--- a/.claude/scripts/otel/docker-compose.yaml
+++ b/.claude/scripts/otel/docker-compose.yaml
@@ -1,0 +1,29 @@
+version: '3'
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    ports:
+      - "19091:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
+      - '--web.console.templates=/usr/share/prometheus/consoles'
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "13000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning
+    depends_on:
+      - prometheus
+    restart: unless-stopped

--- a/.claude/scripts/otel/prometheus.yml
+++ b/.claude/scripts/otel/prometheus.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:19091']
+
+  - job_name: 'otel-collector'
+    static_configs:
+      - targets: ['host.docker.internal:19090']

--- a/.claude/scripts/otel/setup_claude_otel.sh
+++ b/.claude/scripts/otel/setup_claude_otel.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Enable telemetry for Claude Code
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+
+# Configure OTLP exporters
+export OTEL_METRICS_EXPORTER=otlp
+export OTEL_LOGS_EXPORTER=otlp
+
+# Set OTLP endpoint to local collector
+export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:14317
+
+# Optional: Set additional configuration
+export OTEL_SERVICE_NAME=claude-code
+export OTEL_RESOURCE_ATTRIBUTES=service.name=claude-code,deployment.environment=local
+
+echo "OpenTelemetry environment variables set for Claude Code"
+echo "To use these settings in your current shell, run:"
+echo "source ~/.claude/scripts/otel/setup_claude_otel.sh"

--- a/.claude/scripts/otel/start_monitoring.sh
+++ b/.claude/scripts/otel/start_monitoring.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Start the OpenTelemetry collector in the background
+echo "Starting OpenTelemetry collector..."
+cd ~/.claude/scripts/otel
+./otelcol --config=config.yaml &
+OTEL_PID=$!
+
+# Start the monitoring stack
+echo "Starting Prometheus and Grafana..."
+docker-compose up -d
+
+echo ""
+echo "=========================================================="
+echo "Monitoring setup is complete!"
+echo "OpenTelemetry Collector is running with PID: $OTEL_PID"
+echo ""
+echo "Prometheus is available at: http://localhost:19091"
+echo "Grafana is available at: http://localhost:13000"
+echo "  Username: admin"
+echo "  Password: admin"
+echo ""
+echo "To use Claude Code with OpenTelemetry, run:"
+echo "source ~/.claude/scripts/otel/setup_claude_otel.sh"
+echo "=========================================================="

--- a/.claude/scripts/otel/test_integration.md
+++ b/.claude/scripts/otel/test_integration.md
@@ -1,0 +1,44 @@
+# Testing Claude Code OpenTelemetry Integration
+
+Follow these steps to test if the OpenTelemetry integration is working properly:
+
+## Step 1: Start the monitoring stack
+
+```bash
+# Start the OpenTelemetry collector and monitoring tools
+~/.claude/scripts/otel/start_monitoring.sh
+```
+
+## Step 2: Configure Claude Code to use OpenTelemetry
+
+```bash
+# Set the required environment variables
+source ~/.claude/scripts/otel/setup_claude_otel.sh
+```
+
+## Step 3: Run some Claude Code commands
+
+```bash
+# Run a few Claude Code commands to generate telemetry data
+claude-code ls
+claude-code --help
+# Add more commands as needed
+```
+
+## Step 4: Verify the data in monitoring tools
+
+1. Check Prometheus (http://localhost:19091):
+   - Go to Status > Targets to verify that the OpenTelemetry collector endpoint is being scraped
+   - Go to Graph and search for metrics with the prefix `claudecode_`
+
+2. Check Grafana (http://localhost:13000):
+   - Log in with admin/admin
+   - Create a new dashboard
+   - Add panels for metrics with the prefix `claudecode_`
+
+## Troubleshooting
+
+If no metrics appear:
+1. Check that the OpenTelemetry collector is running: `ps aux | grep otelcol`
+2. Verify the environment variables are set: `env | grep OTEL`
+3. Check the collector logs for any errors: `tail -f ~/.claude/scripts/otel/otelcol.log`

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "model": "claude-3-7-sonnet-20250219",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/jeff/.claude/scripts/otel/auto_start_otel.sh"
+          }
+        ]
+      }
+    ]
+  },
+  "env": {
+    "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+    "OTEL_METRICS_EXPORTER": "otlp",
+    "OTEL_LOGS_EXPORTER": "otlp",
+    "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc",
+    "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:14317",
+    "OTEL_SERVICE_NAME": "claude-code"
+  }
+}


### PR DESCRIPTION
## Summary
- Add OpenTelemetry integration configured to use high port numbers (≥10000)
- Configure OpenTelemetry collector on ports 14317 (gRPC) and 14318 (HTTP)
- Set up Prometheus metrics endpoint on port 19090
- Set up Grafana visualization on port 13000
- Add startup scripts and documentation

## Test plan
- Run `~/.claude/scripts/otel/start_monitoring.sh` to start the OpenTelemetry collector
- Run `source ~/.claude/scripts/otel/setup_claude_otel.sh` to set up environment variables
- Verify OpenTelemetry collector is running with `ps aux | grep otelcol`
- Check Prometheus endpoint at http://localhost:19091
- Check Grafana endpoint at http://localhost:13000

🤖 Generated with [Claude Code](https://claude.ai/code)