### PR TITLE
Fix permissions in Claude Code workflow

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -14,6 +14,11 @@ jobs:
     # Skip running the action on the claude-code-action repository itself
     if: github.repository != 'anthropics/claude-code-action'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
     steps:
       - uses: anthropics/claude-code-action@beta
         with:
@@ -25,6 +30,11 @@ jobs:
       github.event.action == 'closed' &&
       github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
     steps:
       - uses: anthropics/claude-code-action@beta
         with:


### PR DESCRIPTION
## Summary
- Added required permissions to the Claude Code workflow
- Added 'id-token: write' permission to fix token authentication issues
- Applied permissions to both jobs in the workflow

## Test plan
- Verify that GitHub workflows execute correctly after the permission fix