### PR TITLE
Add logging to Rust implementation

### DIFF
--- a/rust/audio/piano_player.rs
+++ b/rust/audio/piano_player.rs
@@ -1,4 +1,5 @@
 use super::audio::{AudioPlayer, AudioEngine, NullAudioEngine};
+use log::{info, debug};
 
 pub struct PlayerPiano {
     audio_engine: Box<dyn AudioPlayer>,
@@ -19,24 +20,24 @@ impl PlayerPiano {
 
     pub fn play_keys(&self, keys: &[usize]) {
         if keys.is_empty() {
-            println!("♪ Silence");
+            info!("♪ Silence");
             return;
         }
 
         // Check if this looks like a chord pattern
         let is_chord = self.is_chord_pattern(keys);
         
-        if is_chord {
-            print!("♫ Playing chord: ");
-        } else {
-            print!("♪ Playing piano keys: ");
+        let mut key_str = String::new();
+        for (i, &key) in keys.iter().enumerate() {
+            if i > 0 { key_str.push_str(", "); }
+            key_str.push_str(&format!("{}", key + 1));
         }
         
-        for (i, &key) in keys.iter().enumerate() {
-            if i > 0 { print!(", "); }
-            print!("{}", key + 1);
+        if is_chord {
+            info!("♫ Playing chord: {}", key_str);
+        } else {
+            info!("♪ Playing piano keys: {}", key_str);
         }
-        println!();
 
         self.audio_engine.play_piano_keys(keys);
     }

--- a/rust/life/Cargo.toml
+++ b/rust/life/Cargo.toml
@@ -9,6 +9,8 @@ clap = { version = "4.0", features = ["derive", "env"] }
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.8"
 java-properties = "2.0.0"
+log = "0.4"
+env_logger = "0.10"
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/rust/life/config.rs
+++ b/rust/life/config.rs
@@ -2,6 +2,7 @@ use clap::{Arg, ArgAction, Command, ValueHint};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
+use log::{info, warn, error, debug};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
@@ -177,22 +178,22 @@ impl Config {
     }
 
     pub fn print_config(&self) {
-        println!("Configuration:");
-        println!("  Board Type: {:?}", self.board_type);
-        println!("  Audio Enabled: {}", self.audio_enabled);
-        println!("  Generations: {:?}", self.generations);
+        info!("Configuration:");
+        info!("  Board Type: {:?}", self.board_type);
+        info!("  Audio Enabled: {}", self.audio_enabled);
+        info!("  Generations: {:?}", self.generations);
         
         if let Some(bpm) = self.tempo_bpm {
             let effective_delay = self.get_effective_delay();
-            println!("  Tempo: {:.1} BPM ({}ms per step)", bpm, effective_delay);
+            info!("  Tempo: {:.1} BPM ({}ms per step)", bpm, effective_delay);
         } else {
-            println!("  Step Delay: {}ms", self.step_delay_ms);
+            info!("  Step Delay: {}ms", self.step_delay_ms);
         }
         
         if let Some(ref path) = self.config_file {
-            println!("  Config File: {}", path.display());
+            info!("  Config File: {}", path.display());
         }
-        println!();
+        info!("");
     }
 }
 

--- a/rust/life/src/config_loader.rs
+++ b/rust/life/src/config_loader.rs
@@ -3,6 +3,7 @@
 
 use std::path::PathBuf;
 use std::env;
+use log::{info, warn, error, debug};
 
 // Re-export Config, BoardType, and GenerationLimit from the config module
 pub use crate::config::{Config, BoardType, GenerationLimit};
@@ -90,9 +91,9 @@ pub fn load_config() -> Result<Config, Box<dyn std::error::Error>> {
                 },
                 Err(e) => {
                     // Fall back to traditional config loading
-                    eprintln!("Note: Using legacy config format. Error with unified format: {}", e);
+                    warn!("Note: Using legacy config format. Error with unified format: {}", e);
                     if let Err(e) = config.load_from_file(&default_config) {
-                        eprintln!("Warning: Error loading default config file: {}", e);
+                        warn!("Warning: Error loading default config file: {}", e);
                     }
                 }
             }

--- a/rust/life/src/main.rs
+++ b/rust/life/src/main.rs
@@ -1,45 +1,50 @@
-// Simple program to verify the audio files are in the correct location
+// Simple test program that verifies logging is working
 
 use std::fs;
 use std::path::Path;
+use log::{info, warn, error, debug, trace};
+use env_logger;
 
 fn main() {
-    println!("Testing audio file locations...");
+    // Initialize logger
+    env_logger::init();
     
-    // Check both the old and new paths
+    info!("Conway's Steinway - Logging Test");
+    debug!("This is a debug message");
+    trace!("This is a trace message");
+    
+    // Check audio paths
     let old_path = "../audio-samples";
     let new_path = "../../static/audio";
     
-    println!("Checking old path: {}", old_path);
+    info!("Checking old path: {}", old_path);
     if Path::new(old_path).exists() {
-        println!("  ✓ Old path exists");
+        info!("  ✓ Old path exists");
         let files = fs::read_dir(old_path).unwrap();
         let count = files.count();
-        println!("  - Contains {} files", count);
+        info!("  - Contains {} files", count);
     } else {
-        println!("  ✗ Old path does not exist");
+        warn!("  ✗ Old path does not exist");
     }
     
-    println!("Checking new path: {}", new_path);
+    info!("Checking new path: {}", new_path);
     if Path::new(new_path).exists() {
-        println!("  ✓ New path exists");
+        info!("  ✓ New path exists");
         let files = fs::read_dir(new_path).unwrap();
         let file_count = files.count();
-        println!("  - Contains {} files", file_count);
+        info!("  - Contains {} files", file_count);
         
         // List some files in the new directory
-        println!("  - Files in new directory:");
+        debug!("  - Files in new directory:");
         for entry in fs::read_dir(new_path).unwrap().take(5) {
             let entry = entry.unwrap();
-            println!("    - {}", entry.file_name().to_string_lossy());
+            debug!("    - {}", entry.file_name().to_string_lossy());
         }
         
-        // In a full test, we would instantiate the AudioEngine here to verify
-        // that it can load files from the new location
-        println!("\nNOTE: AudioEngine would attempt to load samples from: {}", new_path);
+        info!("AudioEngine would attempt to load samples from: {}", new_path);
     } else {
-        println!("  ✗ New path does not exist");
+        error!("  ✗ New path does not exist - critical error");
     }
     
-    println!("Audio file check complete.");
+    info!("Logging test complete. Set RUST_LOG=debug or RUST_LOG=trace to see more messages");
 }

--- a/rust/main.rs
+++ b/rust/main.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 use std::thread;
 use std::time::Duration;
+use log::{info, warn, error, debug, trace};
+use env_logger;
 
 // Load modules from life folder
 #[path = "life/game_board.rs"]
@@ -188,14 +190,17 @@ impl fmt::Display for GameOfLife {
 
 
 fn main() {
-    println!("Conway's Steinway - Rust Implementation");
-    println!("======================================");
+    // Initialize logger
+    env_logger::init();
+    
+    info!("Conway's Steinway - Rust Implementation");
+    info!("======================================");
 
     // Load configuration from all sources
     let config = match Config::from_args_and_env() {
         Ok(config) => config,
         Err(e) => {
-            eprintln!("Error loading configuration: {}", e);
+            error!("Error loading configuration: {}", e);
             std::process::exit(1);
         }
     };
@@ -206,14 +211,14 @@ fn main() {
         BoardType::FurElise => {
             // Always use 80 generations for complete musical experience
             if !matches!(config.generations, GenerationLimit::Limited(80)) {
-                println!("Für Elise always uses 80 generations for complete musical experience (ignoring --generations flag)");
+                info!("Für Elise always uses 80 generations for complete musical experience (ignoring --generations flag)");
             }
             config.generations = GenerationLimit::Limited(80);
             
             // Set appropriate musical tempo if not explicitly set
             if config.tempo_bpm.is_none() {
                 config.tempo_bpm = Some(126.0); // Für Elise typical tempo
-                println!("Setting Für Elise tempo to 126 BPM for authentic musical timing");
+                info!("Setting Für Elise tempo to 126 BPM for authentic musical timing");
             }
         },
         _ => {
@@ -227,15 +232,15 @@ fn main() {
     // Initialize the game board based on configuration
     let mut game = match config.board_type {
         BoardType::Static => {
-            println!("Using complex predefined patterns");
+            info!("Using complex predefined patterns");
             GameBoard::create_complex_board()
         },
         BoardType::FurElise => {
-            println!("Using Für Elise melody configuration");
+            info!("Using Für Elise melody configuration");
             GameBoard::create_fur_elise_board()
         },
         BoardType::Random => {
-            println!("Using random board configuration");
+            info!("Using random board configuration");
             GameBoard::create_random_board()
         }
     };
@@ -260,8 +265,8 @@ fn main() {
         step += 1;
         
         match config.generations {
-            GenerationLimit::Limited(max) => println!("\nStep {} of {}", step, max),
-            GenerationLimit::Unlimited => println!("\nStep {} (unlimited)", step),
+            GenerationLimit::Limited(max) => info!("\nStep {} of {}", step, max),
+            GenerationLimit::Unlimited => info!("\nStep {} (unlimited)", step),
         }
         
         let piano_keys = GameBoard::get_bottom_row_and_advance(&mut game);
@@ -270,14 +275,14 @@ fn main() {
         // Use configured delay between steps (respects tempo if set)
         thread::sleep(Duration::from_millis(config.get_effective_delay()));
         
-        println!("\n{}", game);
+        info!("\n{}", game);
 
         // For unlimited generations, allow graceful interruption
         if matches!(config.generations, GenerationLimit::Unlimited) && step % 100 == 0 {
-            println!("(Press Ctrl+C to stop after {} steps)", step);
+            info!("(Press Ctrl+C to stop after {} steps)", step);
         }
     }
     
-    println!("\nSimulation completed after {} generations", step);
-    println!("Final generation: {}", game.generation());
+    info!("\nSimulation completed after {} generations", step);
+    info!("Final generation: {}", game.generation());
 }

--- a/rust/run-rust.sh
+++ b/rust/run-rust.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Change to the rust/life directory where Cargo.toml is located
+cd "$(dirname "$0")/life"
+
+# Run the compiled binary with logging enabled
+RUST_LOG=info cargo run -- "$@"


### PR DESCRIPTION
## Summary
- Added log and env_logger dependencies to Cargo.toml
- Implemented structured logging with different log levels
- Replaced all println/eprintln statements with appropriate logging macros
- Added run-rust.sh script to run with logging enabled
- Demonstrated configurable verbosity via RUST_LOG environment variable

## Test plan
- Run the application with `RUST_LOG=info` to see standard info logs
- Run with `RUST_LOG=debug` or `RUST_LOG=trace` to see more detailed logs
- Verify that logs include timestamps and proper formatting

Fixes #13

🤖 Generated with [Claude Code](https://claude.ai/code)